### PR TITLE
Edlib GH #3162: Add fields for ContentType and ContentTypeName

### DIFF
--- a/src/Lti/Edlib/DeepLinking/EdlibContentItemMapper.php
+++ b/src/Lti/Edlib/DeepLinking/EdlibContentItemMapper.php
@@ -40,6 +40,8 @@ final readonly class EdlibContentItemMapper implements ContentItemMapperInterfac
                 ->withShared(Prop::getOfType($data, 'shared', Prop::TYPE_BOOLEAN))
                 ->withTags(Prop::getArrayOfType($data, 'tag', Prop::TYPE_NORMALIZED_STRING))
                 ->withOwnerEmail(Prop::getOfType($data, 'ownerEmail', Prop::TYPE_NORMALIZED_STRING))
+                ->withContentType(Prop::getOfType($data, 'contentType', Prop::TYPE_NORMALIZED_STRING))
+                ->withContentTypeName(Prop::getOfType($data, 'contentTypeName', Prop::TYPE_NORMALIZED_STRING))
             ;
         }
 

--- a/src/Lti/Edlib/DeepLinking/EdlibLtiLinkItem.php
+++ b/src/Lti/Edlib/DeepLinking/EdlibLtiLinkItem.php
@@ -22,6 +22,10 @@ class EdlibLtiLinkItem extends LtiLinkItem
 
     private string|null $ownerEmail = null;
 
+    private string|null $contentType = null;
+
+    private string|null $contentTypeName = null;
+
     /**
      * @var list<string>
      */
@@ -120,6 +124,32 @@ class EdlibLtiLinkItem extends LtiLinkItem
     {
         $self = clone $this;
         $self->ownerEmail = $email;
+
+        return $self;
+    }
+
+    public function getContentType(): string|null
+    {
+        return $this->contentType;
+    }
+
+    public function withContentType(string|null $type): static
+    {
+        $self = clone $this;
+        $self->contentType = $type;
+
+        return $self;
+    }
+
+    public function getContentTypeName(): string|null
+    {
+        return $this->contentTypeName;
+    }
+
+    public function withContentTypeName(string|null $name): static
+    {
+        $self = clone $this;
+        $self->contentTypeName = $name;
 
         return $self;
     }

--- a/src/Lti/Edlib/DeepLinking/EdlibLtiLinkItemSerializer.php
+++ b/src/Lti/Edlib/DeepLinking/EdlibLtiLinkItemSerializer.php
@@ -49,6 +49,14 @@ final readonly class EdlibLtiLinkItemSerializer implements LtiLinkItemSerializer
             if ($item->getOwnerEmail() !== null) {
                 $serialized['ownerEmail'] = $item->getOwnerEmail();
             }
+
+            if ($item->getContentType() !== null) {
+                $serialized['contentType'] = $item->getContentType();
+            }
+
+            if ($item->getContentTypeName() !== null) {
+                $serialized['contentTypeName'] = $item->getContentTypeName();
+            }
         }
 
         return $serialized;

--- a/tests/Lti/Edlib/EdlibContentItemMapperTest.php
+++ b/tests/Lti/Edlib/EdlibContentItemMapperTest.php
@@ -35,6 +35,8 @@ final class EdlibContentItemMapperTest extends TestCase
                     'shared' => false,
                     'tag' => 'foo',
                     'ownerEmail' => 'owner@example.com',
+                    'contentType' => 'fake.fancy_content',
+                    'contentTypeName' => 'FancyContent',
                 ],
             ],
         ]);
@@ -50,6 +52,8 @@ final class EdlibContentItemMapperTest extends TestCase
         $this->assertTrue($items[0]->isPublished());
         $this->assertSame(['foo'], $items[0]->getTags());
         $this->assertSame('owner@example.com', $items[0]->getOwnerEmail());
+        $this->assertSame('fake.fancy_content', $items[0]->getContentType());
+        $this->assertSame('FancyContent', $items[0]->getContentTypeName());
     }
 
     public function testMapsMultipleTags(): void

--- a/tests/Lti/Edlib/EdlibContentItemsSerializerTest.php
+++ b/tests/Lti/Edlib/EdlibContentItemsSerializerTest.php
@@ -28,6 +28,8 @@ final class EdlibContentItemsSerializerTest extends TestCase
                 ->withShared(true)
                 ->withTags(['foo'])
                 ->withOwnerEmail('owner@example.com')
+                ->withContentType('fake.fancy_content')
+                ->withContentTypeName('FancyContent')
         ]);
 
         $this->assertArrayHasKey('@context', $data);
@@ -65,6 +67,12 @@ final class EdlibContentItemsSerializerTest extends TestCase
 
         $this->assertArrayHasKey('ownerEmail', $data['@graph'][0]);
         $this->assertSame('owner@example.com', $data['@graph'][0]['ownerEmail']);
+
+        $this->assertArrayHasKey('contentType', $data['@graph'][0]);
+        $this->assertSame('fake.fancy_content', $data['@graph'][0]['contentType']);
+
+        $this->assertArrayHasKey('contentTypeName', $data['@graph'][0]);
+        $this->assertSame('FancyContent', $data['@graph'][0]['contentTypeName']);
     }
 
     public function testSerializesMultipleTags(): void


### PR DESCRIPTION
[Edlib issue #3162](https://github.com/cerpus/Edlib/issues/3162)
Add new fields for `contentType` and `contentTypeName` used for transferring H5P library machine name and H5P library title